### PR TITLE
メッセージ送信機能追加

### DIFF
--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -39,10 +39,14 @@
       background-color: #2f3e51;
       height: calc(100vh - 100px);
       padding: 20px 20px 0;
-      &-list {
+      &__list {
         margin-bottom: 40px;
         color: $section-color;
         font-weight: $section-font-weight;
+        a{
+          color: $section-color;
+          text-decoration: none;
+        }
         &__name {
           font-size: 15px;
           margin-bottom: 5px;
@@ -64,29 +68,31 @@
       justify-content: space-between;
       padding: 0 40px;
       &__name {
-        color: #333333;
-        font-size: 20px;
-        margin-top: 35px;
-        margin-bottom: 15px;
         &__name-list {
-          color: #999999;
-          font-size: 12px;
-          display: flex;
-          margin-top: 15px;
           &__group {
-            color: #999999;
-            font-size: 12px;
+            color: #333333;
+            font-size: 20px;
+            margin-bottom: 10px;
+            margin-top: 35px;
           }
+          &__title {
+            font-size: 12px;
+            color: #999999;
+          }
+          
         }
       }
       &__edit {
-        color: #38aef0;
         border: solid 1px #38aef0;
         padding: 0 20px;
         height: 40px;
         margin-bottom: 28px;
         margin-top: 30px;
         line-height: 40px;
+        &--btn {
+          text-decoration: none;
+          color: #38aef0;
+        }
       }
     }
     &__message-list{
@@ -119,35 +125,46 @@
       background-color: #d2d2d2;
       height: 90px;
       padding: 20px 40px;
-      display: flex;
-      justify-content: space-around;
       &__text {
         width: 100%;
         position: relative;
-        &__message {
+        .form__message {
+          float: left;
           line-height: 50px;
           padding-left: 10px;
-          width: 100%;
+          width: calc(100% - 150px);
           border: none;
           position: relative;
         }
-        .far {
+        .input-box__image {
+          float: left;
           margin-right: 10px;
-          position: absolute;
-          top: 10px;
+          // position: absolute;
+          // top: 10px;
           right: 10px;
-          font-size: 20px;
+          // font-size: 20px;
+          padding-right: 10px;
+          line-height: 50px;
+          height: 50px;
+          background-color: white;
+          .far {
+
+          }
+          #image {
+            display: none;
+          }
+          .hidden {
+            display: none;
+          }
         }
-        #image {
-          display: none;
+        .form__submit {
+          float: right;
+          padding: 0 30px;
+          margin-left: 15px;
+          background-color: #38aef0;
+          color: $section-color;
+          line-height: 50px;
         }
-      }
-      &__send {
-        padding: 0 30px;
-        margin-left: 15px;
-        background-color: #38aef0;
-        color: $section-color;
-        line-height: 50px;
       }
     }
   }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,7 +24,7 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group), notice: 'グループを更新しました'
     else
       render :edit
     end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,26 +1,23 @@
-.messages
-  = render @messages
-
 .chat-main
   .chat-main__group-info
     .chat-main__group-info__name
       .chat-main__group-info__name__name-list
-        .chat-main__group-info__name__title
-          Member：
-        .chat-main__group-info__name__group
-          test
+        .chat-main__group-info__name__name-list__group
+          = @group.name
+        .chat-main__group-info__name__name-list__title
+          ="Member: " + @group.users.pluck(:name).join(" , ")
     .chat-main__group-info__edit
-      = link_to edit_group_path(@group), class: ".chat-main__group-info__edit-btn" do
+      = link_to edit_group_path(@group), class: "chat-main__group-info__edit--btn" do
         Edit
 
+  .chat-main__message-list
+    = render @messages
 
-  .chat-main__message-form
+  = form_for [@group, @message], html: { class:"chat-main__message-form" } do |f|
     .chat-main__message-form__text
-      = form_for [@group, @message] do |f|
-        = f.text_field :content, class: 'form__message', placeholder: 'type a message'
-        %label{class: "input-box__image", for:"image"}
-          = f.label :image, class: 'form__mask__image' do
-            = icon('far', 'image')
-            = f.file_field :image, class: 'hidden'
-        .chat-main__message-form__send
-          = f.submit 'Send', class: 'form__submit'
+      = f.text_field :content, class: 'form__message', placeholder: 'type a message'
+      = f.label :image, class: 'input-box__image' do
+        = icon('far', 'image')
+        = f.file_field :image, class: 'hidden'
+      .chat-main__message-form__send
+        = f.submit 'Send', class: 'form__submit'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,11 +1,12 @@
-.chat-main__message-list
-  .chat-main__message-list__all
-    .chat-main__message-list__all__status
-      .chat-main__message-list__all__status__member 
-        = message.user.name
-      .chat-main__message-list__all__status__date
-        = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-    .chat-main__message-list__all__message
-      - if message.content.present?
+
+.chat-main__message-list__all
+  .chat-main__message-list__all__status
+    .chat-main__message-list__all__status__member 
+      = message.user.name
+    .chat-main__message-list__all__status__date
+      = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  .chat-main__message-list__all__message
+    - if message.content.present?
+      %p.lower-message__content
         = message.content
-      = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -10,9 +10,9 @@
           = icon('fas', 'cog')
   .side-bar__group
     - current_user.groups.each do |group|
-      .side-bar__group-list
+      .side-bar__group__list
         = link_to group_messages_path(group) do
-          .side-bar__group-list__name
+          .side-bar__group__list__name
             = group.name
-          .side-bar__group-list__message
+          .side-bar__group__list__message
             = group.show_last_message

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -2,5 +2,5 @@
   = render "side_bar"
   = render "main_chat"
 
-.messages
-  = render @messages
+-# .messages
+-#   = render @messages

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root 'groups#index'
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:index, :new, :create, :edit, :update]
+  # resources :groups, only: [:index, :new, :create, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
#what
　・ビュー崩れの修正
　・送信機能の追加
　・グループにメッセージを表示する
　・サイドバーに最新のメッセージを表示する
　・ヘッダーにグループ名とユーザー名が表示されるようにする
　・グループ編集ページへのリンクを設置する　
　・グループ編集後のリダイレクト先を変更する
#why
　追加作業実施に伴い一時保存(マージ)の為